### PR TITLE
Update prices and workshop CTA buttons

### DIFF
--- a/_data/pricetable.yml
+++ b/_data/pricetable.yml
@@ -1,4 +1,4 @@
-pricetable-subtitle: Pricetable - Early Bird tickets are now on sale until May 26th. 
+pricetable-subtitle: Pricetable - Standard tickets are now on sale until August 12th.
 pricetable-title: Scala Days 2025
 pricetable-description: |
   {: .lead}
@@ -8,10 +8,10 @@ pricetable-subtitle-workshops: Pricetable
 pricetable-title-workshops: Workshops
 pricetable-description-workshops: |
   {: .lead}
-  All workshops are **2-day** courses and will be offered on **August 18 and 19**. Each workshop will conclude before the opening keynote on August 19th. All workshops require a minimum of 9 participants to run. <br><br> 
-  **All workshop attendees will receive a certificate of completion following the end of the conference.** 
-  
-  
+  All workshops are **2-day** courses and will be offered on **August 18 and 19**. Each workshop will conclude before the opening keynote on August 19th. All workshops require a minimum of 9 participants to run. <br><br>
+  **All workshop attendees will receive a certificate of completion following the end of the conference.**
+
+
   {: .lead}
   Stay Tuned! More information about each workshop will be published soon.
 
@@ -29,7 +29,7 @@ pricetable:
     date: Including VAT
     cta: Register now
     cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
-  
+
   - title: Workshop
     state: active
     price: CHF 700
@@ -81,8 +81,8 @@ pricetable-workshops:
   - title: Functional Stream Processing
     workshop-id: zainab
     state: active
-    price1: CHF 700
-    price2: CHF 1395
+    price1: CHF 800
+    price2: CHF 1490
     description: "Led by Zainab Ali"
     date: Including VAT
     cta: Register now
@@ -90,8 +90,8 @@ pricetable-workshops:
   - title: Functional Programming Strategies
     workshop-id: noel
     state: active
-    price1: CHF 700
-    price2: CHF 1395
+    price1: CHF 800
+    price2: CHF 1490
     description: "Led by Noel Welsh"
     date: Including VAT
     cta: Register now
@@ -99,8 +99,8 @@ pricetable-workshops:
   - title: Real-World Zio
     workshop-id: daniel
     state: active
-    price1: CHF 700
-    price2: CHF 1395
+    price1: CHF 800
+    price2: CHF 1490
     description: "Led by Daniel Ciocirlan"
     date: Including VAT
     cta: Register now
@@ -108,8 +108,8 @@ pricetable-workshops:
   - title: Domain Driven Design in Scala 3
     workshop-id: david
     state: active
-    price1: CHF 700
-    price2: CHF 1395
+    price1: CHF 800
+    price2: CHF 1490
     description: "Led by David Amancio Gil Méndez"
     date: Including VAT
     cta: Register now
@@ -117,8 +117,8 @@ pricetable-workshops:
   - title: Effective Programming in Scala with Friendly Agents
     workshop-id: virtuslab
     state: active
-    price1: CHF 700
-    price2: CHF 1395
+    price1: CHF 800
+    price2: CHF 1490
     description: "Led by Tomasz Godzik and Łukasz Biały"
     date: Including VAT
     cta: Register now

--- a/_data/pricetable.yml
+++ b/_data/pricetable.yml
@@ -85,8 +85,8 @@ pricetable-workshops:
     price2: CHF 1490
     description: "Led by Zainab Ali"
     date: Including VAT
-    cta: Register now
-    cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
+    cta: Learn More
+    cta-url: /editions/2025/workshops/functional-stream-processing/
   - title: Functional Programming Strategies
     workshop-id: noel
     state: active
@@ -94,8 +94,8 @@ pricetable-workshops:
     price2: CHF 1490
     description: "Led by Noel Welsh"
     date: Including VAT
-    cta: Register now
-    cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
+    cta: Learn More
+    cta-url: /editions/2025/workshops/functional-programming-strategies/
   - title: Real-World Zio
     workshop-id: daniel
     state: active
@@ -103,8 +103,8 @@ pricetable-workshops:
     price2: CHF 1490
     description: "Led by Daniel Ciocirlan"
     date: Including VAT
-    cta: Register now
-    cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
+    cta: Learn More
+    cta-url: /editions/2025/workshops/real-world-zio/
   - title: Domain Driven Design in Scala 3
     workshop-id: david
     state: active
@@ -112,8 +112,8 @@ pricetable-workshops:
     price2: CHF 1490
     description: "Led by David Amancio Gil Méndez"
     date: Including VAT
-    cta: Register now
-    cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
+    cta: Learn More
+    cta-url: /editions/2025/workshops/ddd-in-scala-3/
   - title: Effective Programming in Scala with Friendly Agents
     workshop-id: virtuslab
     state: active
@@ -121,5 +121,5 @@ pricetable-workshops:
     price2: CHF 1490
     description: "Led by Tomasz Godzik and Łukasz Biały"
     date: Including VAT
-    cta: Register now
-    cta-url: https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/
+    cta: Learn More
+    cta-url: /editions/2025/workshops/efficient-programming-in-scala-with-friendly-agents/

--- a/_includes/_pricetable-home.html
+++ b/_includes/_pricetable-home.html
@@ -21,8 +21,8 @@
         </th>
          </th class="align-top">
           <th style="width: 20%;">
-            <h4 class="text-uppercase mb-0 mt-2">Early Bird</h4>
-            <span class="fw-normal mb-3 d-block">Price ends on May 29.</span>
+            <h4 class="text-uppercase mb-0 mt-2"><s>Early Bird</s></h4>
+            <span class="fw-normal mb-3 d-block"><s>Price ends on May 29.</s></span>
         </th>
         <th style="width: 20%;">
             <h4 class="text-uppercase mb-0 mt-2">Standard</h4>
@@ -38,15 +38,15 @@
         <tr>
           <th scope="row" class="text-start">Conference ticket</th>
           <td class="inactive"><s>CHF 750</s></td>
-          <td class="active">CHF 850</td>
-          <td class="inactive">CHF 950</td>
+          <td class="inactive"><s>CHF 850</s></td>
+          <td class="active">CHF 950</td>
           <td class="inactive">CHF 1050</td>
         </tr>
         <tr>
           <th scope="row" class="text-start">Workshop ticket</th>
           <td class="align-middle inactive"><s>CHF 600</s></td>
-          <td class="align-middle active">CHF 700</td>
-          <td class="align-middle inactive">CHF 800</td>
+          <td class="align-middle inactive"><s>CHF 700</s></td>
+          <td class="align-middle active">CHF 800</td>
           <td class="align-middle inactive">CHF 900</td>
         </tr>
       </tbody>
@@ -54,23 +54,23 @@
       <tbody>
         <tr>
           <th scope="row" class="text-start">Bundle (Conference + Workshop) ticket</th>
-          <td class="align-middle inactive"><s>CHF 600</s></td>
-          <td class="align-middle active">CHF 1395</td>
-          <td class="align-middle inactive">CHF 1490</td>
+          <td class="align-middle inactive"><s>CHF 1200</s></td>
+          <td class="align-middle inactive"><s>CHF 1395</s></td>
+          <td class="align-middle active">CHF 1490</td>
           <td class="align-middle inactive">CHF 1755</td>
         </tr>
         <tr>
           <th scope="row" class="text-start">Student Conference Ticket</th>
           <td class="align-middle inactive"><s>CHF 400</s></td>
+          <td class="align-middle inactive"><s>CHF 400</s></td>
           <td class="align-middle active">CHF 400</td>
-          <td class="align-middle inactive">CHF 400</td>
           <td class="align-middle inactive">CHF 400</td>
         </tr>
         <tr>
           <th scope="row" class="text-start">One-Day Conference Ticket</th>
           <td class="align-middle inactive"><s>CHF 560</s></td>
+          <td class="align-middle inactive"><s>CHF 560</s></td>
           <td class="align-middle active">CHF 560</td>
-          <td class="align-middle inactive">CHF 560</td>
           <td class="align-middle inactive">CHF 560</td>
         </tr>
       </tbody>

--- a/_includes/_pricetable.html
+++ b/_includes/_pricetable.html
@@ -15,8 +15,8 @@
               </th>
                </th class="align-top">
                 <th style="width: 20%;">
-                  <h4 class="text-uppercase mb-0 mt-2">Early Bird</h4>
-                  <span class="fw-normal mb-3 d-block">Price ends on May 29.</span>
+                  <h4 class="text-uppercase mb-0 mt-2"><s>Early Bird</s></h4>
+                  <span class="fw-normal mb-3 d-block"><s>Price ends on May 29.</s></span>
               </th>
               <th style="width: 20%;">
                   <h4 class="text-uppercase mb-0 mt-2">Standard</h4>
@@ -32,15 +32,15 @@
               <tr>
                 <th scope="row" class="text-start">Conference ticket</th>
                 <td class="inactive"><s>CHF 750</s></td>
-                <td class="active">CHF 850</td>
-                <td class="inactive">CHF 950</td>
+                <td class="inactive"><s>CHF 850</s></td>
+                <td class="active">CHF 950</td>
                 <td class="inactive">CHF 1050</td>
               </tr>
               <tr>
                 <th scope="row" class="text-start">Workshop ticket</th>
                 <td class="align-middle inactive"><s>CHF 600</s></td>
-                <td class="align-middle active">CHF 700</td>
-                <td class="align-middle inactive">CHF 800</td>
+                <td class="align-middle inactive"><s>CHF 700</s></td>
+                <td class="align-middle active">CHF 800</td>
                 <td class="align-middle inactive">CHF 900</td>
               </tr>
             </tbody>
@@ -49,22 +49,22 @@
               <tr>
                 <th scope="row" class="text-start">Bundle (Conference + Workshop) ticket</th>
                 <td class="align-middle inactive"><s>CHF 1200</s></td>
-                <td class="align-middle active">CHF 1395</td>
-                <td class="align-middle inactive">CHF 1490</td>
+                <td class="align-middle inactive"><s>CHF 1395</s></td>
+                <td class="align-middle active">CHF 1490</td>
                 <td class="align-middle inactive">CHF 1755</td>
               </tr>
               <tr>
                 <th scope="row" class="text-start">Student Conference Ticket</th>
                 <td class="align-middle inactive"><s>CHF 400</s></td>
+                <td class="align-middle inactive"><s>CHF 400</s></td>
                 <td class="align-middle active">CHF 400</td>
-                <td class="align-middle inactive">CHF 400</td>
                 <td class="align-middle inactive">CHF 400</td>
               </tr>
               <tr>
                 <th scope="row" class="text-start">One-Day Conference Ticket</th>
                 <td class="align-middle inactive"><s>CHF 560</s></td>
+                <td class="align-middle inactive"><s>CHF 560</s></td>
                 <td class="align-middle active">CHF 560</td>
-                <td class="align-middle inactive">CHF 560</td>
                 <td class="align-middle inactive">CHF 560</td>
               </tr>
             </tbody>

--- a/_posts/2025-05-15-workshop-abstracts.md
+++ b/_posts/2025-05-15-workshop-abstracts.md
@@ -9,7 +9,7 @@ description: Take a look at MORE workshop details and book your ticket today bef
 ---
 {: .mt-5}
 
-We’ve met each of the Scala Days workshop trainers, but here’s some more information on what each workshop will actually include! Continue reading below to review the abstracts to each workshop. 
+We’ve met each of the Scala Days workshop trainers, but here’s some more information on what each workshop will actually include! Continue reading below to review the abstracts to each workshop.
 
 
 ### Real-World ZIO by Daniel Ciocirlan
@@ -77,11 +77,11 @@ Will touch on subjects such as MCP, agents, scripting, migration, refactoring an
 
 Each workshop takes place on August 18th and 19th in Lausanne. Upon completion workshop participants will also receive a certificate.
 
-Grab your ticket today before the Early Bird sale ends on May 26th!
+Grab your ticket today before the Standard ticket sale ends on August 12th!
 
 <div class="d-flex justify-content-center align-items-center">
   <a class="btn btn-primary btn-lg fw-bold my-4" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/">View Ticket Options and Register</a>
 </div>
 
-Still need help deciding which workshop or ticket option to choose? 
-Contact us at [info@scaladays.org](mailto:info@scaladays.org), we’ll do our best to answer your questions and welcome you this August. 
+Still need help deciding which workshop or ticket option to choose?
+Contact us at [info@scaladays.org](mailto:info@scaladays.org), we’ll do our best to answer your questions and welcome you this August.


### PR DESCRIPTION
- Prices bumped from Early Bird to Standard
- Workshop CTA buttons are changed from "Register" to "Learn More"
- Workshop CTA buttons lead to the individual workshop pages, where the attendees can register via the "Register" button

![image](https://github.com/user-attachments/assets/c2bb0dac-5785-416a-a349-b93926106705)
![image](https://github.com/user-attachments/assets/79e03672-0ce0-4c82-85ec-dc9f2b288faa)
![image](https://github.com/user-attachments/assets/42c6f483-8278-498b-902a-0547f694f828)
