### PR TITLE
Add more CTA buttons to various pages

### DIFF
--- a/_includes/_hero-sponsor-editions.html
+++ b/_includes/_hero-sponsor-editions.html
@@ -10,6 +10,7 @@
         <h2 class="fw-bold mb-4">{{ site.data.conference.sponsor-hero-description}}</h2>
         <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
           <a class="btn btn-primary btn-lg px-4 gap-3" href="#the-sponsor">{{ site.data.conference.sponsor-hero-cta}}</a>
+          <a class="btn btn-primary btn-lg px-4 gap-3" href="mailto:info@scaladays.org">Get in Touch</a>
         </div>
       </div>
     </div>
@@ -19,4 +20,4 @@
       <img src="{{ site.baseurl }}/img/assets/icon-arrow.svg" alt="">
     </a>
   </div>
-</header> 
+</header>

--- a/_includes/_hero-workshops.html
+++ b/_includes/_hero-workshops.html
@@ -11,6 +11,7 @@
         </h2>
         <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
           <a class="btn btn-primary btn-lg px-4 gap-3" href="#workshops">Learn more</a>
+          <a class="btn btn-primary btn-lg px-4 gap-3" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/" target="_blank" rel="noopener noreferrer">Buy Ticket Now</a>
         </div>
       </div>
     </div>
@@ -20,4 +21,4 @@
       <img src="{{ site.baseurl }}/img/assets/icon-arrow.svg" alt="">
     </a>
   </div>
-</header> 
+</header>

--- a/_includes/_pricetable-workshops.html
+++ b/_includes/_pricetable-workshops.html
@@ -8,6 +8,9 @@
         <h2 class="mb-4">{{site.data.pricetable.pricetable-title-workshops }}</h2>
         <div>{{site.data.pricetable.pricetable-description-workshops | markdownify }}</div>
       </div>
+      <div class="col-md-4 d-flex align-items-center justify-content-end">
+        <a class="btn btn-primary btn-lg px-4 gap-3" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/" target="_blank" rel="noopener noreferrer">Buy Ticket Now</a>
+      </div>
     </div>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 text-center aos-animate" data-aos="fade-in">
       {% for item in site.data.pricetable.pricetable-workshops %}
@@ -26,20 +29,20 @@
                 <br><span class="fs-5 fw-normal text-muted">bundle:</span> {{ item.price2 }}
                 {% endif %}
               </h4>
-              
+
 
               {% assign trainer = site.data.workshops[item.workshop-id] %}
             <!-- Trainer info -->
             <div class="trainer-info text-center mt-3">
               <div class="trainer-img-wrapper mb-3 d-flex justify-content-center">
-                <img 
+                <img
                   class="trainer-img"
                   src="{{ site.baseurl }}{{ trainer.image }}"
                   alt="Trainer: {{ trainer.name }}"
                   style="
-                    width: 200px; 
-                    height: 200px; 
-                    object-fit: cover; 
+                    width: 200px;
+                    height: 200px;
+                    object-fit: cover;
                     border-radius: 50%;
                   "
                 />
@@ -52,16 +55,16 @@
               <!-- Icons linking to LinkedIn and GitHub -->
               <div class="trainer-links d-flex justify-content-center gap-2">
                 <a href="{{ trainer.linkedin }}" target="_blank" rel="noopener">
-                  <img 
-                    src="{{ site.baseurl }}/img/assets/icon-linkedin.svg" 
-                    alt="LinkedIn" 
+                  <img
+                    src="{{ site.baseurl }}/img/assets/icon-linkedin.svg"
+                    alt="LinkedIn"
                     style="height: 24px;"
                   >
                 </a>
                 <a href="{{ trainer.github }}" target="_blank" rel="noopener">
-                  <img 
-                    src="{{ site.baseurl }}/img/assets/icon-github.svg" 
-                    alt="GitHub" 
+                  <img
+                    src="{{ site.baseurl }}/img/assets/icon-github.svg"
+                    alt="GitHub"
                     style="height: 24px;"
                   >
                 </a>
@@ -80,6 +83,13 @@
         </div>
       </div>
       {% endfor %}
+    </div>
+    <div class="row mt-5">
+      <div class="col-md-7 mx-auto">
+        <div class="d-flex justify-content-center align-items-center">
+          <a class="btn btn-primary btn-lg px-4 gap-3" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/" target="_blank" rel="noopener noreferrer">Buy Ticket Now</a>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/_includes/_pricetable.html
+++ b/_includes/_pricetable.html
@@ -77,6 +77,13 @@
               </div>
           </div>
         </div>
+        <div class="row mt-4">
+          <div class="col-md-7 mx-auto">
+              <div class="d-flex justify-content-center align-items-center">
+                <a class="btn btn-primary btn-lg px-4 gap-3" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/" target="_blank" rel="noopener noreferrer">Buy Ticket Now</a>
+              </div>
+          </div>
+        </div>
 
   </div>
 </section>

--- a/schedule.html
+++ b/schedule.html
@@ -28,6 +28,9 @@ permalink: schedule
         <div class="alert alert-info text-center" role="alert">
           <small><i class="bi bi-info-circle me-2"></i>Please note that the schedule is subject to change. We recommend checking back regularly for updates.</small>
         </div>
+        <div class="d-flex justify-content-center mt-2">
+          <a class="btn btn-primary btn-lg px-4 gap-3" href="https://register.event-works.com/lausanne/Scaladays2025/e/lk/k/" target="_blank" rel="noopener noreferrer">Buy Ticket Now</a>
+        </div>
         <div class="tab-content" id="nav-tabContent">
           {% for day in site.data.schedule.days %}
           <div class="tab-pane fade {% if forloop.first %} show active {% endif %}" id="{{day.id}}" role="tabpanel" aria-labelledby="{{day.id}}-list">


### PR DESCRIPTION
- [x]  Tickets page: Below the prices of tickets.
- [x]  Workshops page: Hero, before workshop list, and after.
- [x]  Schedule page: before and after schedule.
- [x]  Sponsors page: Get in Touch button.

![Screenshot 2025-06-09 140721](https://github.com/user-attachments/assets/290d1200-8514-4e2b-a3d4-b63e26533946)
![Screenshot 2025-06-09 140549](https://github.com/user-attachments/assets/ba208324-97be-4c41-bcc8-f46889cfa656)
![Screenshot 2025-06-09 140545](https://github.com/user-attachments/assets/878637e4-35bc-4ba8-96da-30d5d8809a28)
![Screenshot 2025-06-09 140200](https://github.com/user-attachments/assets/3d1e1181-ae62-4e99-81cf-de72e2ee2e4c)
![Screenshot 2025-06-09 140154](https://github.com/user-attachments/assets/07486b1f-dea1-4d1c-9703-22b940783418)
![Screenshot 2025-06-09 140148](https://github.com/user-attachments/assets/0db9c4b4-e104-4e43-8c9c-b17e4f7241bf)
