### PR TITLE
Improve schedule layout

### DIFF
--- a/_sass/_user-styles.scss
+++ b/_sass/_user-styles.scss
@@ -13,7 +13,7 @@
 
 
 
-/* 
+/*
 .site-nav-home {
     .navbar-nav {
         .nav-item {
@@ -468,7 +468,7 @@ th {
 }
 
 .item-schedule {
-    height: 12rem;
+    height: 14rem;
     transition: box-shadow linear 166ms;
     //@extend .border-top;
 
@@ -496,7 +496,7 @@ th {
 }
 
 .talk-title {
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 4;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
@@ -506,7 +506,7 @@ th {
     @extend .p-4;
     @extend .bg-secondary;
     color: $white;
-    height: 12rem;
+    height: 14rem;
 }
 
 // Sponsors
@@ -517,7 +517,7 @@ th {
         //opacity: 0.7;
         transition: all linear 166ms;
         bottom: 0;
-        
+
     }
 
     &:hover {

--- a/schedule.html
+++ b/schedule.html
@@ -38,7 +38,7 @@ permalink: schedule
               {% for stageId in day.stages %}
               {% assign stage = site.data.schedule.stages | find: "id", stageId %}
               <div class="col-lg-{{ 12 | divided_by: day.stages.size }} mt-5">
-                <h3 class="d-flex align-items-center mt-4 mb-5 text-uppercase fs-5">
+                <h3 class="d-flex align-items-center mt-4 mb-5 text-uppercase fs-5 overflow-hidden" style="min-height:3.5rem;">
                 <img class="icon-stage" src="{{ site.baseurl }}/img/assets/icon-stage.svg" alt="">
                 {% if stage.description %}
                   <span class="stage-title-tooltip" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ stage.description }}">{{ stage.title }}</span>

--- a/schedule.html
+++ b/schedule.html
@@ -49,18 +49,23 @@ permalink: schedule
                 {% assign talks = site.data.schedule.talks-2025 | where_exp: "talk", "talk.day == day.id and talk.stage contains stage.id" | sort: "time" %}
                 {% for talk in talks %}
                 {% if talk.special %}
-                <div class="break d-block text-decoration-none {% if talk.special == 'blank' %} opacity-0 {% endif %} ">
-                  {% if talk.time and talk.time != 0%}
-                  <span class="badge ps-0 fs-6 bg-secondary pl-4 mb-3">{{ talk.time }}</span>
-                  {% endif %}
-                  <div class="d-flex align-items-center">
-                    <img class="icon-time-slot" width="32" height="32" src="{{ site.baseurl }}/img/assets/icon-{{ talk.special }}.svg" alt="{{ talk.special }}">
-                    <h5 class="talk-title mb-0 ms-3">{{ talk.title }}</h5>
+                {% if talk.special == 'blank' %}
+                  <!-- Only show invisible break on large screens -->
+                  <div class="break d-none d-lg-block text-decoration-none opacity-0"></div>
+                {% else %}
+                  <div class="break d-block text-decoration-none">
+                    {% if talk.time and talk.time != 0 %}
+                      <span class="badge ps-0 fs-6 bg-secondary pl-4 mb-3">{{ talk.time }}</span>
+                    {% endif %}
+                    <div class="d-flex align-items-center">
+                      <img class="icon-time-slot" width="32" height="32" src="{{ site.baseurl }}/img/assets/icon-{{ talk.special }}.svg" alt="{{ talk.special }}">
+                      <h5 class="talk-title mb-0 ms-3">{{ talk.title }}</h5>
+                    </div>
+                    {% if talk.info %}
+                      <p class="mt-3 mb-0">{{ talk.info }}</p>
+                    {% endif %}
                   </div>
-                  {% if talk.info %}
-                  <p class="mt-3 mb-0">{{ talk.info }}</p>
-                  {% endif %}
-                </div>
+                {% endif %}
                 {% else %}
                 <a class="item-schedule border d-block text-decoration-none text-dark" href="{{ talk.url | relative_url }}">
                   <span class="badge fs-6 bg-secondary pl-4">{{ talk.time }}</span>


### PR DESCRIPTION
Several changes:

First, many talks are longer than 2 lines, but are clipped at 2 lines, so the schedule can now handle up to 4 lines:

![image](https://github.com/user-attachments/assets/d097eef5-1feb-4cd7-b6e7-07df8e96cfeb)

Second, on mobile, the blank talk slots were still rendered, resulting in an ugly padding. Now this behavior is corrected:

![image](https://github.com/user-attachments/assets/ceaafcd3-75bc-42f1-abb8-773113a16ccb)

Finally, a minor fix preventing the schedule being shifted by stage name wrapping to a new line on smaller screens.