### PR TITLE
Refactored speaker profile

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -888,7 +888,7 @@ speakers:
     on scalable software solutions at Sky in London, focusing on backend development
     with functional Scala. She has also contributed to various Scala projects in India,
     specializing in data engineering, and has expertise in Scala, Akka, and big data
-    technologies.
+    technologies.'
   talk: scala-meets-genai-build-the
   linkedin: https://www.linkedin.com/in/kannupriyakalra/
   twitter: https://x.com/KannupriyaKalra

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -889,10 +889,8 @@ speakers:
     with functional Scala. She has also contributed to various Scala projects in India,
     specializing in data engineering, and has expertise in Scala, Akka, and big data
     technologies.
-
-    Learn more about her on LinkedIn: https://www.linkedin.com/in/kannupriyakalra/'
   talk: scala-meets-genai-build-the
-  # linkedin: ''
+  linkedin: https://www.linkedin.com/in/kannupriyakalra/
   twitter: https://x.com/KannupriyaKalra
   github: https://github.com/kannupriyakalra
 - name: Szymon Rodziewicz


### PR DESCRIPTION
Removed LinkedIn URL from bio and added it to dedicated LinkedIn field for icon display so viewers can click on url.