### PR TITLE
Obfuscate "sponsor" from CSS to avoid adblocker

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -5,10 +5,10 @@
 sponsorship-types:
   - title: Platinum
     icon: img/assets/icon-platinum.svg
-    css-class: sponsor-logo-platinum
+    css-class: org-feature-logo-platinum
   - title: Gold
     icon: img/assets/icon-gold.svg
-    css-class: sponsor-logo-gold
+    css-class: org-feature-logo-gold
 
 sponsors:
   - title: VirtusLab

--- a/_includes/_sponsors-footer.html
+++ b/_includes/_sponsors-footer.html
@@ -1,16 +1,16 @@
 <!-- Sponsors Footer Section -->
-<section class="sponsors-footer py-5">
+<section class="org-features-footer py-5">
   <div class="container">
     <div class="row justify-content-center mb-4">
       <div class="col-12 text-center">
-        <div class="sponsors-footer-title">Brought to you by our sponsors</div>
-        <div class="sponsors-footer-row sponsors-footer-row-big">
+        <div class="org-features-footer-title">Brought to you by our sponsors</div>
+        <div class="org-features-footer-row org-features-footer-row-big">
           {% assign platinum_sponsors = site.data.sponsors.sponsors | where: "type", "Platinum" %}
           {% assign big_sponsors = platinum_sponsors %}
           {% for sponsor in big_sponsors %}
-            <span class="sponsor-footer-item">
-              <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="sponsor-link">
-                <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="sponsor-logo sponsor-logo-big">
+            <span class="org-feature-footer-item">
+              <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="org-feature-link">
+                <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="org-feature-logo org-feature-logo-big">
               </a>
             </span>
           {% endfor %}
@@ -19,16 +19,16 @@
     </div>
     <div class="row justify-content-center">
       <div class="col-12 text-center">
-        <div class="sponsors-footer-row sponsors-footer-row-small">
+        <div class="org-features-footer-row org-features-footer-row-small">
           {% assign gold_sponsors = site.data.sponsors.sponsors | where: "type", "Gold" %}
           {% assign silver_sponsors = site.data.sponsors.sponsors | where: "type", "Silver" %}
           {% assign bronze_sponsors = site.data.sponsors.sponsors | where: "type", "Bronze" %}
           {% assign media_sponsors = site.data.sponsors.sponsors | where: "type", "Media" %}
           {% assign small_sponsors = gold_sponsors | concat: silver_sponsors | concat: bronze_sponsors | concat: media_sponsors %}
           {% for sponsor in small_sponsors %}
-            <span class="sponsor-footer-item">
-              <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="sponsor-link">
-                <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="sponsor-logo sponsor-logo-small">
+            <span class="org-feature-footer-item">
+              <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="org-feature-link">
+                <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="org-feature-logo org-feature-logo-small">
               </a>
             </span>
           {% endfor %}

--- a/_includes/_sponsors-hero.html
+++ b/_includes/_sponsors-hero.html
@@ -1,5 +1,5 @@
 <!-- Sponsors Section - Below Hero -->
-<section class="sponsors-hero py-5">
+<section class="org-features-hero py-5">
   <div class="container">
     <div class="row">
       <div class="col-12 text-center">
@@ -12,16 +12,16 @@
         {% for type in site.data.sponsors.sponsorship-types %}
           {% assign type_sponsors = site.data.sponsors.sponsors | where: "type", type.title %}
           {% if type_sponsors.size > 0 %}
-            <div class="sponsor-type-section mb-5">
-              <div class="sponsor-type-header text-center mb-4">
-                <img src="{{ site.baseurl }}/{{ type.icon }}" alt="{{ type.title }}" class="sponsor-type-icon me-3">
+            <div class="org-feature-type-section mb-5">
+              <div class="org-feature-type-header text-center mb-4">
+                <img src="{{ site.baseurl }}/{{ type.icon }}" alt="{{ type.title }}" class="org-feature-type-icon me-3">
                 <h4 class="d-inline">{{ type.title }}</h4>
               </div>
-              <div class="sponsors-grid">
+              <div class="org-features-grid">
                 {% for sponsor in type_sponsors %}
-                  <div class="sponsor-item">
-                    <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="sponsor-link">
-                      <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="sponsor-logo {{ type.css-class }}">
+                  <div class="org-feature-item">
+                    <a href="{{ sponsor.url }}" target="_blank" rel="noopener noreferrer" class="org-feature-link">
+                      <img src="{{ site.baseurl }}/{{ sponsor.logo }}" alt="{{ sponsor.title }}" class="org-feature-logo {{ type.css-class }}">
                     </a>
                   </div>
                 {% endfor %}

--- a/_includes/_sponsors-home.html
+++ b/_includes/_sponsors-home.html
@@ -1,4 +1,4 @@
-<section id="sponsors" class="pt-5">
+<section id="org-features" class="pt-5">
   <div class="container py-0 py-lg-5">
     <div class="row mb-5">
       <div class="col-md-6">
@@ -32,7 +32,7 @@
           {% for sponsor-item in sponsors-tier.sponsor-list %} {% if sponsors-tier.type
           == "Platinum" %}
           <div class="col-md-4 mb-4">
-            <a class="d-block sponsor-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
+            <a class="d-block org-feature-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
               <img
                 class="img-fluid w-100"
                 src="{{ site.baseurl }}/{{sponsor-item.logo}}"
@@ -42,7 +42,7 @@
           </div>
           {% endif %} {% if sponsors-tier.type == "Gold" %}
           <div class="col-6 col-md-3 mb-4">
-            <a class="d-block sponsor-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
+            <a class="d-block org-feature-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
               <img
                 class="img-fluid w-100"
                 src="{{ site.baseurl }}/{{sponsor-item.logo}}"
@@ -52,7 +52,7 @@
           </div>
           {% endif %} {% if sponsors-tier.type == "Silver" %}
           <div class="col-4 col-md-2 mb-4">
-            <a class="d-block sponsor-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
+            <a class="d-block org-feature-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
               <img
                 class="img-fluid w-100"
                 src="{{ site.baseurl }}/{{sponsor-item.logo}}"
@@ -62,7 +62,7 @@
           </div>
           {% endif %} {% if sponsors-tier.type == "Bronze" %}
           <div class="col-4 col-md-2 mb-4">
-            <a class="d-block sponsor-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
+            <a class="d-block org-feature-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
               <img
                 class="img-fluid w-100"
                 src="{{ site.baseurl }}/{{sponsor-item.logo}}"
@@ -72,7 +72,7 @@
           </div>
           {% endif %} {% if sponsors-tier.type == "Media" %}
           <div class="col-4 col-md-2 mb-4">
-            <a class="d-block sponsor-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
+            <a class="d-block org-feature-item" href="{{sponsor-item.url}}" target="_blank" rel="noopener noreferrer">
               <img
                 class="img-fluid w-100"
                 src="{{ site.baseurl }}/{{sponsor-item.logo}}"

--- a/_sass/_user-styles.scss
+++ b/_sass/_user-styles.scss
@@ -201,7 +201,7 @@
         background-size: cover;
     }
 
-    &.sponsor {
+    &.org-feature {
         background: url("../../img/assets/hero-background-sponsor.jpg") no-repeat center center;
         background-size: cover;
     }
@@ -510,7 +510,7 @@ th {
 }
 
 // Sponsors
-.sponsor-item {
+.org-feature-item {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -533,7 +533,7 @@ th {
 }
 
 // Hero Sponsors Section
-.sponsors-hero {
+.org-features-hero {
     position: relative;
 
     .container {
@@ -542,7 +542,7 @@ th {
     }
 }
 
-.sponsors-grid {
+.org-features-grid {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -556,7 +556,7 @@ th {
     }
 }
 
-.sponsor-link {
+.org-feature-link {
     display: block;
     text-decoration: none;
     transition: all 0.3s ease;
@@ -566,7 +566,7 @@ th {
     }
 }
 
-.sponsor-logo {
+.org-feature-logo {
     max-width: 180px;
     max-height: 80px;
     width: auto;
@@ -582,7 +582,7 @@ th {
         filter: drop-shadow(0 0 10px rgba(8, 131, 183, 0.3));
     }
 
-    &.sponsor-logo-gold {
+    &.org-feature-logo-gold {
         max-width: 120px;
         max-height: 50px;
         width: auto;
@@ -590,7 +590,7 @@ th {
     }
 }
 
-.sponsor-type-section {
+.org-feature-type-section {
     margin-bottom: 3rem;
 
     &:last-child {
@@ -598,7 +598,7 @@ th {
     }
 }
 
-.sponsor-type-header {
+.org-feature-type-header {
     margin-bottom: 2rem;
 
     h4 {
@@ -608,7 +608,7 @@ th {
     }
 }
 
-.sponsor-type-icon {
+.org-feature-type-icon {
     width: 32px;
     height: 32px;
     vertical-align: middle;
@@ -643,13 +643,13 @@ th {
 }
 
 // Sponsors Footer Section
-.sponsors-footer {
+.org-features-footer {
     background: #e13c26;
     color: #fff;
     text-align: center;
 }
 
-.sponsors-footer-title {
+.org-features-footer-title {
     font-size: 1.25rem;
     font-weight: 500;
     margin-bottom: 2rem;
@@ -658,7 +658,7 @@ th {
     letter-spacing: 0.02em;
 }
 
-.sponsors-footer-row {
+.org-features-footer-row {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -667,37 +667,37 @@ th {
     margin-bottom: 1.5rem;
 }
 
-.sponsor-footer-item {
+.org-feature-footer-item {
     display: flex;
     align-items: center;
     justify-content: center;
     margin: 0 1.5rem;
     transition: transform 0.3s ease, filter 0.3s ease;
 
-    &:hover .sponsor-logo {
+    &:hover .org-feature-logo {
         transform: translateY(-5px);
         filter: brightness(0) invert(1) drop-shadow(0 0 3px #fff) !important;
     }
 }
 
-.sponsor-logo {
+.org-feature-logo {
     transition: filter 0.3s ease, transform 0.3s ease;
 }
 
-.sponsor-logo-big {
+.org-feature-logo-big {
     max-width: 180px;
     max-height: 80px;
     width: auto;
     height: 80px;
 }
 
-.sponsor-logo-small {
+.org-feature-logo-small {
     max-width: 100px;
     max-height: 40px;
     width: auto;
     height: 40px;
 }
 
-.sponsors-footer .sponsor-logo {
+.org-features-footer .org-feature-logo {
     filter: brightness(0) invert(1) !important;
 }


### PR DESCRIPTION
On Chrome with AdBlock, sponsor logos are getting hidden. Most probably this is happening because of the word "sponsor" in the CSS classes, so this PR obfuscates away that keyword.